### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node index.js"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Uptime Checker
+[![Run on Repl.it](https://repl.it/badge/github/glennfaison/uptime-checker)](https://repl.it/github/glennfaison/uptime-checker)
 
 ![Home Page](./public/screenshots/landing_page.jpg)
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).